### PR TITLE
Add Dynamic Feature Toggles for Monster Lines and Ground Effects

### DIFF
--- a/Tracker/GroundEffect.cs
+++ b/Tracker/GroundEffect.cs
@@ -1,4 +1,4 @@
-﻿using GameHelper;
+using GameHelper;
 using GameHelper.RemoteObjects.Components;
 using GameHelper.Utils;
 using ImGuiNET;
@@ -21,6 +21,8 @@ namespace Tracker
         /// </summary>
         public void Draw()
         {
+            if (!Settings.ShowGroundEffects) return;
+
             var areaInstance = Core.States.InGameStateObject.CurrentAreaInstance;
             var groundEffects = areaInstance.AwakeEntities
                 .Where(entity => GroundEffects.Exists(effect => entity.Value.Path.StartsWith(effect.GroundEffect)))

--- a/Tracker/MonsterLine.cs
+++ b/Tracker/MonsterLine.cs
@@ -1,4 +1,4 @@
-﻿using GameHelper;
+using GameHelper;
 using GameHelper.RemoteEnums;
 using GameHelper.RemoteEnums.Entity;
 using GameHelper.RemoteObjects.Components;
@@ -30,14 +30,23 @@ namespace Tracker
             if (!player.TryGetComponent<Render>(out var playerRender)) return;
             var playerlocation = Core.States.InGameStateObject.CurrentWorldInstance.WorldToScreen(playerRender.WorldPosition);
 
-            foreach (var entity in GetMonsters(Rarity.Unique))
-                _drawMonsterLine(entity, Settings.UniqueLineColor);
+            if (Settings.ShowUniqueLine)
+            {
+                foreach (var entity in GetMonsters(Rarity.Unique))
+                    _drawMonsterLine(entity, Settings.UniqueLineColor);
+            }
 
-            foreach (var entity in GetMonsters(Rarity.Rare))
-                _drawMonsterLine(entity, Settings.RareLineColor);
+            if (Settings.ShowRareLine)
+            {
+                foreach (var entity in GetMonsters(Rarity.Rare))
+                    _drawMonsterLine(entity, Settings.RareLineColor);
+            }
 
-            foreach (var entity in GetMonsters(Rarity.Magic))
-                _drawMonsterLine(entity, Settings.MagicLineColor);
+            if (Settings.ShowMagicLine)
+            {
+                foreach (var entity in GetMonsters(Rarity.Magic))
+                    _drawMonsterLine(entity, Settings.MagicLineColor);
+            }
 
             void _drawMonsterLine(Entity entity, Vector4 color)
             {

--- a/Tracker/Tracker.cs
+++ b/Tracker/Tracker.cs
@@ -1,4 +1,4 @@
-﻿namespace Tracker
+namespace Tracker
 {
     using GameHelper.Plugin;
     using ImGuiNET;
@@ -59,6 +59,12 @@
             ImGui.ColorEdit4("Ground effect color", ref Settings.GroundEffectColor);
             ImGui.InputTextMultiline("Ground effects", ref Settings.GroundEffects, 8000, new System.Numerics.Vector2(500, 100));
             ImGui.InputTextMultiline("Monster status effects", ref Settings.MonsterStatusEffects, 8000, new System.Numerics.Vector2(500, 100));
+
+            // Add checkboxes to enable/disable features
+            ImGui.Checkbox("Show unique monster lines", ref Settings.ShowUniqueLine);
+            ImGui.Checkbox("Show rare monster lines", ref Settings.ShowRareLine);
+            ImGui.Checkbox("Show magic monster lines", ref Settings.ShowMagicLine);
+            ImGui.Checkbox("Show ground effects", ref Settings.ShowGroundEffects);
         }
 
         /// <summary>

--- a/Tracker/TrackerSettings.cs
+++ b/Tracker/TrackerSettings.cs
@@ -1,4 +1,4 @@
-﻿namespace Tracker
+namespace Tracker
 {
     using GameHelper.Plugin;
     using System.Numerics;
@@ -14,6 +14,12 @@
         public Vector4 GroundEffectColor = new Vector4(1.0f, 0.0f, 0.0f, 0.5f);
         public string GroundEffects = string.Empty;
         public string MonsterStatusEffects = "shocked|Shocked|0xFF00FFFF\nproximal_intangibility|Intangible|0xFFFF00FF";
+
+        // New settings for checkboxes
+        public bool ShowUniqueLine = true;
+        public bool ShowRareLine = true;
+        public bool ShowMagicLine = true;
+        public bool ShowGroundEffects = true;
 
         public TrackerSettings()
         {


### PR DESCRIPTION
This pull request introduces dynamic feature toggles for rendering monster lines and ground effects in the tracker. Users can now enable or disable specific features through the settings menu using checkboxes. The changes include:

1. MonsterLine Rendering:
- Added conditional logic to respect ShowUniqueLine, ShowRareLine, and ShowMagicLine settings.
- Each monster line type is drawn only if the corresponding setting is enabled.

2. GroundEffect Rendering:
- Added a toggle for ShowGroundEffects to enable or disable ground effect visualization.

3. Updated Settings UI:
- Integrated ImGui checkboxes in the DrawSettings method for user-friendly toggling of features.